### PR TITLE
Browser support

### DIFF
--- a/src/views/HighlightView.vue
+++ b/src/views/HighlightView.vue
@@ -93,14 +93,14 @@ onMounted( updateProgress );
 
 <style>
 .wiki-highlight-view {
-	height: calc( 100vh - 40px );
+	height: calc( 100vh - 110px );
 	height: 100dvh;
 	overflow-y: scroll;
 	scroll-snap-type: y mandatory;
 }
 
 .wiki-highlight-view > .wiki-highlight-view-card {
-	height: calc( 100vh - 40px );
+	height: calc( 100vh - 110px );
 	height: 100dvh;
 	padding-bottom: 50px;
 	scroll-snap-stop: always;

--- a/src/views/HighlightView.vue
+++ b/src/views/HighlightView.vue
@@ -138,6 +138,9 @@ onMounted( updateProgress );
 }
 
 .wiki-highlight-view-swipe {
+	position: absolute;
+	bottom: 25px;
+	width: 100%;
 	text-align: center;
 }
 

--- a/src/views/HighlightView.vue
+++ b/src/views/HighlightView.vue
@@ -93,15 +93,15 @@ onMounted( updateProgress );
 
 <style>
 .wiki-highlight-view {
-	height: 100dvh;
 	height: 100vh;
+	height: 100dvh;
 	overflow-y: scroll;
 	scroll-snap-type: y mandatory;
 }
 
 .wiki-highlight-view > .wiki-highlight-view-card {
-	height: 100dvh;
 	height: 100vh;
+	height: 100dvh;
 	padding-bottom: 50px;
 	scroll-snap-stop: always;
 	scroll-snap-align: start;
@@ -169,8 +169,8 @@ onMounted( updateProgress );
 }
 
 .wiki-highlight-thumb {
-	max-height: 40dvh;
 	max-height: 40vh;
+	max-height: 40dvh;
 }
 
 .wiki-highlight-view-card-discover-header {

--- a/src/views/HighlightView.vue
+++ b/src/views/HighlightView.vue
@@ -138,9 +138,6 @@ onMounted( updateProgress );
 }
 
 .wiki-highlight-view-swipe {
-	position: absolute;
-	bottom: 25px;
-	width: 100%;
 	text-align: center;
 }
 

--- a/src/views/HighlightView.vue
+++ b/src/views/HighlightView.vue
@@ -93,14 +93,14 @@ onMounted( updateProgress );
 
 <style>
 .wiki-highlight-view {
-	height: 100vh;
+	height: calc( 100vh - 40px );
 	height: 100dvh;
 	overflow-y: scroll;
 	scroll-snap-type: y mandatory;
 }
 
 .wiki-highlight-view > .wiki-highlight-view-card {
-	height: 100vh;
+	height: calc( 100vh - 40px );
 	height: 100dvh;
 	padding-bottom: 50px;
 	scroll-snap-stop: always;

--- a/src/views/HighlightView.vue
+++ b/src/views/HighlightView.vue
@@ -94,12 +94,14 @@ onMounted( updateProgress );
 <style>
 .wiki-highlight-view {
 	height: 100dvh;
+	height: 100vh;
 	overflow-y: scroll;
 	scroll-snap-type: y mandatory;
 }
 
 .wiki-highlight-view > .wiki-highlight-view-card {
 	height: 100dvh;
+	height: 100vh;
 	padding-bottom: 50px;
 	scroll-snap-stop: always;
 	scroll-snap-align: start;
@@ -168,6 +170,7 @@ onMounted( updateProgress );
 
 .wiki-highlight-thumb {
 	max-height: 40dvh;
+	max-height: 40vh;
 }
 
 .wiki-highlight-view-card-discover-header {

--- a/vite.config.js
+++ b/vite.config.js
@@ -13,5 +13,8 @@ export default defineConfig({
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url))
     }
+  },
+  build: {
+    target: 'es2015'
   }
 })


### PR DESCRIPTION
https://phabricator.wikimedia.org/T349134 

Used Browserstack to test in many devices and across browsers, both the highlights view as well as the longtext form. The app is testing fairly well in all devices and browsers, the only two issues I was able to find:

* The highlights view wouldn't load in iPhone 11 v13 in Chrome, just a blank page and accompanying error message. Using Vite's own [build config option](https://vitejs.dev/guide/build.html#browser-compatibility), we can set `build.target`  to `es2015` to transpile the code correctly and fix this.
<img width="340" alt="image" src="https://github.com/wikimedia/wiki-highlights/assets/4752599/b8b4d8f2-1323-4928-b2b2-13b7ba94f0c3">


* In browsers where the new CSS unit `dvh` is not supported yet, the images in HighlightCard appeared to not render at all, because as `dvh` is invalid it wouldn't set any height at all. Setting a fallback height with `vh` fixes this. Note when `dvh` is not supported the 'Swipe up for more' text is hidden and content is still scrollable. 
<img width="792" alt="image" src="https://github.com/wikimedia/wiki-highlights/assets/4752599/1aad138d-1fe2-4c3c-a324-615b4136e214">

Besides that testing well in iOS and Android, a sampled selection:

### iOS
<img width="768" alt="image" src="https://github.com/wikimedia/wiki-highlights/assets/4752599/1aef9def-082b-43c5-8792-a0d9d8c325e2">


### Android

<img width="1035" alt="image" src="https://github.com/wikimedia/wiki-highlights/assets/4752599/231cae44-8e04-45fe-add8-d9b6bb2632f3">




