### PR TITLE
max height for discover more thumb only

### DIFF
--- a/src/views/HighlightView.vue
+++ b/src/views/HighlightView.vue
@@ -166,7 +166,7 @@ onMounted( updateProgress );
 	place-content: start;
 }
 
-.wiki-highlight-thumb {
+.wiki-highlight-thumb-discover .wiki-highlight-thumb {
 	max-height: 40dvh;
 }
 


### PR DESCRIPTION
this should only apply to discover section, not for the home page.

this will fix the homepage on bigger screen

| from: | to: |
| --- | --- |
| <img width="415" alt="image" src="https://github.com/wikimedia/wiki-highlights/assets/2560096/489b32f7-0f8a-4956-9d52-ba378de70f93"> |   <img width="409" alt="image" src="https://github.com/wikimedia/wiki-highlights/assets/2560096/de7f1f30-b5ac-48de-bf1d-b975c37dff38"> |
