### PR TITLE
T352250: Add dark mode style updates

### DIFF
--- a/src/assets/base.css
+++ b/src/assets/base.css
@@ -4,7 +4,7 @@
   --vt-c-white-soft: #f8f8f8;
   --vt-c-white-mute: #f2f2f2;
 
-  --vt-c-black: #181818;
+  --vt-c-black: #27292D;
   --vt-c-black-soft: #222222;
   --vt-c-black-mute: #282828;
 

--- a/src/views/ArticleView.vue
+++ b/src/views/ArticleView.vue
@@ -375,7 +375,7 @@ header {
 
 @media ( prefers-color-scheme: dark ) {
 	a {
-		color: #69F;
+		color: #69f;
 	}
 
 	.navicon {

--- a/src/views/ArticleView.vue
+++ b/src/views/ArticleView.vue
@@ -375,7 +375,7 @@ header {
 
 @media ( prefers-color-scheme: dark ) {
 	a {
-		color: #6699FF;
+		color: #69F;
 	}
 
 	.navicon {
@@ -398,7 +398,7 @@ header {
 	}
 
 	.footer .ext-related-articles-card-list .ext-related-articles-card {
-		background-color: #27292D;
+		background-color: #27292d;
 	}
 
 	.footer .ext-related-articles-card-list .ext-related-articles-card-extract {

--- a/src/views/ArticleView.vue
+++ b/src/views/ArticleView.vue
@@ -75,6 +75,8 @@ const transforms = {
 			'.pcs-collapse-table-container',
 			'.pcs-edit-section-link-container',
 			'.hatnote',
+			'.side-box',
+			'.quotebox',
 			"[ role='navigation' ]",
 			'header'
 		].join( ',' );
@@ -261,16 +263,6 @@ header {
 	margin-top: 6px;
 }
 
-@media ( prefers-color-scheme: dark ) {
-	.navicon {
-		background-image: url( ../assets/back-arrow-white.svg );
-	}
-
-	.content :deep( h2::before ) {
-		background-image: url( ../assets/collapse-light.svg );
-	}
-}
-
 .content :deep( .collapsible *:not( :first-child  ) ) {
 	display: none;
 }
@@ -327,6 +319,8 @@ header {
 	height: 100%;
 	width: 80px;
 	margin-right: 10px;
+	position: relative;
+	z-index: 1;
 }
 
 .footer .ext-related-articles-card-list .ext-related-articles-card > a {
@@ -377,5 +371,38 @@ header {
 
 .footer .footer-info {
 	margin-top: 15px;
+}
+
+@media ( prefers-color-scheme: dark ) {
+	a {
+		color: #6699FF;
+	}
+
+	.navicon {
+		background-image: url( ../assets/back-arrow-white.svg );
+	}
+
+	.content :deep( h2::before ) {
+		background-image: url( ../assets/collapse-light.svg );
+	}
+
+	header,
+	.content :deep( h2.pcs-edit-section-title ),
+	.footer .read-more-container h2 {
+		color: #eaecf0;
+	}
+
+	.content :deep( p ),
+	.content :deep( figcaption ) {
+		color: #c8ccd1;
+	}
+
+	.footer .ext-related-articles-card-list .ext-related-articles-card {
+		background-color: #27292D;
+	}
+
+	.footer .ext-related-articles-card-list .ext-related-articles-card-extract {
+		color: #c8ccd1;
+	}
 }
 </style>

--- a/src/views/CategoriesView.vue
+++ b/src/views/CategoriesView.vue
@@ -82,7 +82,7 @@ defineProps( {
 		color: unset;
 
 		a {
-			color: #6699FF;
+			color: #69F;
 		}
 	}
 }

--- a/src/views/CategoriesView.vue
+++ b/src/views/CategoriesView.vue
@@ -80,6 +80,10 @@ defineProps( {
 	.wiki-highlight-categories-license {
 		background-color: unset;
 		color: unset;
+
+		a {
+			color: #6699FF;
+		}
 	}
 }
 </style>

--- a/src/views/CategoriesView.vue
+++ b/src/views/CategoriesView.vue
@@ -82,7 +82,7 @@ defineProps( {
 		color: unset;
 
 		a {
-			color: #69F;
+			color: #69f;
 		}
 	}
 }


### PR DESCRIPTION
Follow up for https://phabricator.wikimedia.org/T352250

- Dark mode general background color: background-color: #27292D
- Dark mode color text for article header, section titles and 'related articles': color: #EAECF0
- Dark mode article body text and footer and figcaption/image caption: #C8CCD1
- Dark mode `<a>` tag link color: #6699FF
- Remove side box and quotebox [1]

Demo: https://wikimedia.github.io/wiki-highlights/dark-mode-style-updates-dec20/#/highlights

---

[1]
<img width="370" alt="image" src="https://github.com/wikimedia/wiki-highlights/assets/4752599/87211b23-e8cc-4fdf-817c-a28109f74245">
